### PR TITLE
Add ability to set 'current_default' for model

### DIFF
--- a/lib/data_works/base.rb
+++ b/lib/data_works/base.rb
@@ -13,6 +13,7 @@ module DataWorks
       method_name = method_name.to_s
       if method_name =~ /\A(add_|the_)(\w+)\Z/ ||
          method_name =~ /\A(\w+)(\d+)\Z/ ||
+         method_name =~ /\A(set_|clear_)current_default\Z/ ||
          method_name == 'visualize'
         @works.send(method_name, *args, &block)
       else

--- a/lib/data_works/version.rb
+++ b/lib/data_works/version.rb
@@ -1,4 +1,4 @@
 module DataWorks
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end
 

--- a/lib/data_works/works.rb
+++ b/lib/data_works/works.rb
@@ -6,6 +6,8 @@ module DataWorks
     def initialize
       # we keep a registry of all models that we create
       @data = {}
+      # keep a registry of the 'current default' model of a given type
+      @current_default = {}
     end
 
     def method_missing(method_name, *args, &block)
@@ -26,6 +28,14 @@ module DataWorks
       model_name = model_name.to_sym
       @data[model_name] ||= []
       @data[model_name] << model
+    end
+
+    def set_current_default(model, record)
+      @current_default[model] = record
+    end
+
+    def clear_current_default(model)
+      @current_default[model] = nil
     end
 
   private
@@ -61,8 +71,12 @@ module DataWorks
 
     def find(model_name, index)
       model_name = model_name.to_sym
-      @data[model_name] ||= []
-      @data[model_name][index.to_i-1]
+      if index == 1 && @current_default[model_name]
+        @current_default[model_name]
+      else
+        @data[model_name] ||= []
+        @data[model_name][index.to_i-1]
+      end
     end
 
   end


### PR DESCRIPTION
Previously when accessing a record either as an automatic parent or
through `#the_model_name` method it was always the first created record
of the given type that was returned.

Now you can set the `current_default` for a given model. This is useful
if you want to associate a number of records with one parent and then
another bunch of records to another parent of the same type.

Addresses: https://github.com/dmcouncil/data_works/issues/8
